### PR TITLE
Add a :synopsis keyword to (read|load)-data-stream.

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -503,7 +503,7 @@ returns no value. The stream should accept
 
 
 <p><a name='load-data-stream'>[Function]</a><br>
-<b>load-data-stream</b> <i>file</i> => <i>data-stream</i>
+<b>load-data-stream</b> <i>file</i> <tt>&amp;key</tt> <i>synopsis</i> => <i>data-stream</i>
 
 <blockquote>
 
@@ -521,19 +521,24 @@ anyway)
 
 </ul>
 
-<p>
+<p>If <i>synopsis</i> is non-NIL, don't read the raster data, just the
+  image metadata.
 
 </blockquote>
 
 
 <p><a name='read-data-stream'>[Function]</a><br>
-<b>read-data-stream</b> <i>stream</i> => <i>data-stream</i>
+<b>read-data-stream</b> <i>stream</i> <tt>&amp;key</tt> <i>synopsis</i> => <i>data-stream</i>
 
 <blockquote>
 Reads a GIF89a or GIF87a data stream from <i>stream</i> and returns it
 as a SKIPPY data stream object. The stream should be compatible with
 reading <tt>(UNSIGNED-BYTE&nbsp;8)</tt> data via <tt>CL:READ-BYTE</tt>
 and <tt>CL:READ-SEQUENCE</tt>.
+
+<p>If <i>synopsis</i> is non-NIL, don't read the raster data, just the
+  image metadata.
+
 </blockquote>
 
 

--- a/load-gif.lisp
+++ b/load-gif.lisp
@@ -276,7 +276,7 @@ streams); wrap it."
              :source stream
              :position pos))))
 
-(defun read-data-stream (stream)
+(defun read-data-stream (stream &key synopsis)
   (check-gif-signature stream)
   (let ((width (read-uint16 stream))
         (height (read-uint16 stream))
@@ -292,16 +292,17 @@ streams); wrap it."
          (sorted-flag             1)
          (global-color-table-size 3))
       (declare (ignore color-resolution sorted-flag))
-      (when (plusp global-color-table-flag)
+      (when (and (plusp global-color-table-flag) (not synopsis))
         (let ((color-table-entry-count (expt 2 (1+ global-color-table-size))))
           (setf color-table (read-color-table color-table-entry-count
                                               stream))))
       (let ((data-stream (make-data-stream :height height
                                            :width width
                                            :color-table color-table)))
-        (process-objects data-stream stream)
+	(when (not synopsis)
+	  (process-objects data-stream stream))
         data-stream))))
             
-(defun load-data-stream (file)
+(defun load-data-stream (file &key synopsis)
   (with-open-file (stream file :direction :input :element-type 'octet)
-    (read-data-stream stream)))
+    (read-data-stream stream :synopsis synopsis)))


### PR DESCRIPTION
Hi.

Would you consider this patch to add a synopisis feature? It does change the signature of read-data-stream and load-data-stream, but not incompatibly. 

The :synopsis keyword allows reading only the metadata instead of the whole image.